### PR TITLE
Add image hash migration and IndexedDB caching for product media

### DIFF
--- a/components/RetryImage.jsx
+++ b/components/RetryImage.jsx
@@ -17,6 +17,17 @@ const RetryImage = ({
   const retryCountRef = useRef(0);
 
   const handleError = () => {
+    // blob URL 失败后重试没有意义（blob 被释放就不会恢复），直接标记失败
+    if (src && src.startsWith('blob:')) {
+      console.log('blob URL 加载失败，不重试:', src);
+      setHasError(true);
+      setIsLoading(false);
+      if (onFinalError) {
+        onFinalError();
+      }
+      return;
+    }
+
     retryCountRef.current += 1;
     setRetryCount(retryCountRef.current);
     

--- a/pages/shop.js
+++ b/pages/shop.js
@@ -953,15 +953,20 @@ export default function Shop() {
     }
   }, []);
 
+  // 组件卸载时清理所有 blob URL（注意：不要依赖 cachedImageUrls，否则每次更新都会触发清理）
+  const cachedImageUrlsRef = useRef(cachedImageUrls);
+  cachedImageUrlsRef.current = cachedImageUrls;
+  
   useEffect(() => () => {
-    Object.values(cachedImageUrls || {}).forEach((url) => {
+    // 只在组件卸载时清理
+    Object.values(cachedImageUrlsRef.current || {}).forEach((url) => {
       try {
         URL.revokeObjectURL(url);
       } catch (err) {
         console.warn('清理图片缓存URL失败', err);
       }
     });
-  }, [cachedImageUrls]);
+  }, []); // 空依赖，只在卸载时执行
 
   // 加载商品和分类（只在首次加载或位置变化时调用）
   const loadData = async () => {

--- a/utils/imageCache.js
+++ b/utils/imageCache.js
@@ -1,0 +1,122 @@
+import { getProductImage } from './urls';
+
+const DB_NAME = 'smart-shop-images';
+const STORE_NAME = 'productImages';
+const DB_VERSION = 1;
+
+const isClient = typeof window !== 'undefined' && typeof indexedDB !== 'undefined';
+
+function openDatabase() {
+  if (!isClient) return Promise.resolve(null);
+
+  return new Promise((resolve) => {
+    const request = indexedDB.open(DB_NAME, DB_VERSION);
+
+    request.onupgradeneeded = (event) => {
+      const db = event.target.result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        const store = db.createObjectStore(STORE_NAME, { keyPath: 'productId' });
+        store.createIndex('hash', 'hash', { unique: false });
+      }
+    };
+
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => resolve(null);
+  });
+}
+
+function runRequest(request) {
+  return new Promise((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+async function getRecord(db, productId) {
+  if (!db) return null;
+  const tx = db.transaction(STORE_NAME, 'readonly');
+  const store = tx.objectStore(STORE_NAME);
+  return runRequest(store.get(productId)).catch(() => null);
+}
+
+async function saveRecord(db, record) {
+  if (!db) return;
+  const tx = db.transaction(STORE_NAME, 'readwrite');
+  const store = tx.objectStore(STORE_NAME);
+  store.put(record);
+  return new Promise((resolve) => {
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => resolve();
+  });
+}
+
+async function pruneMissingProducts(db, validIds) {
+  if (!db) return;
+  const tx = db.transaction(STORE_NAME, 'readwrite');
+  const store = tx.objectStore(STORE_NAME);
+  const cursorRequest = store.openCursor();
+
+  cursorRequest.onsuccess = (event) => {
+    const cursor = event.target.result;
+    if (!cursor) return;
+    if (!validIds.has(cursor.primaryKey)) {
+      cursor.delete();
+    }
+    cursor.continue();
+  };
+
+  return new Promise((resolve) => {
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => resolve();
+  });
+}
+
+function getImageHash(product = {}) {
+  return product.image_hash || product.img_hash || product.imageHash || '';
+}
+
+export async function syncProductImageCache(products = []) {
+  if (!isClient) return { urls: {} };
+
+  const db = await openDatabase();
+  if (!db) return { urls: {} };
+
+  const productIds = new Set(products.map((p) => p.id).filter(Boolean));
+  await pruneMissingProducts(db, productIds);
+
+  const urls = {};
+
+  for (const product of products) {
+    const productId = product.id;
+    const hash = getImageHash(product);
+    const imageUrl = getProductImage(product);
+
+    if (!productId || !hash || !imageUrl) continue;
+
+    try {
+      const existing = await getRecord(db, productId);
+      if (existing && existing.hash === hash && existing.blob) {
+        urls[productId] = URL.createObjectURL(existing.blob);
+        continue;
+      }
+
+      const response = await fetch(imageUrl, { credentials: 'include' });
+      if (!response.ok) throw new Error(`图片获取失败: ${response.status}`);
+      const blob = await response.blob();
+
+      await saveRecord(db, {
+        productId,
+        hash,
+        blob,
+        storedAt: Date.now(),
+        imageUrl,
+      });
+
+      urls[productId] = URL.createObjectURL(blob);
+    } catch (err) {
+      console.error('同步图片缓存失败', err);
+    }
+  }
+
+  return { urls };
+}

--- a/utils/urls.js
+++ b/utils/urls.js
@@ -34,6 +34,7 @@ export function resolveImageUrl(path) {
 export function getProductImage(product) {
   if (!product) return '';
   const src =
+    product.cached_image_url ||
     product.image_url ||
     product.img_url ||
     product.image ||

--- a/utils/urls.js
+++ b/utils/urls.js
@@ -9,8 +9,8 @@ const DEFAULT_API_BASE = imageBaseUrl || fileBaseUrl || apiUrl
 export function resolveImageUrl(path) {
   if (!path || typeof path !== 'string') return '';
 
-  // Already absolute or protocol-relative
-  if (/^https?:\/\//i.test(path) || path.startsWith('//')) return path;
+  // Already absolute, protocol-relative, or blob URL
+  if (/^https?:\/\//i.test(path) || path.startsWith('//') || path.startsWith('blob:')) return path;
 
   // 在浏览器环境中，优先使用相对路径以利用Next.js的rewrites代理
   if (typeof window !== 'undefined') {


### PR DESCRIPTION
## Summary
- add product image hash metadata, update image uploads to persist hashes, and expose the values in product APIs
- backfill hashes for legacy products during startup to keep existing media cached reliably
- introduce an IndexedDB-backed product image cache in the shop that syncs against hashes to reuse unchanged images

## Testing
- npm run lint *(fails: missing NEXT_PUBLIC_API_URL, NEXT_PUBLIC_IMAGE_BASE_URL, NEXT_PUBLIC_FILE_BASE_URL, SHOP_NAME env vars in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6927fe64dd24832196aa2e1526d5ae02)