### PR TITLE
feat(admin): add chat audit panel with configurable retention

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -8,6 +8,7 @@ from .routes import (
     auth_router,
     cart_router,
     catalog_router,
+    chat_audit_router,
     coupons_router,
     images_router,
     locations_router,
@@ -36,6 +37,7 @@ def build_app() -> FastAPI:
     app.include_router(products_manage_router)
     app.include_router(settings_router)
     app.include_router(ai_router)
+    app.include_router(chat_audit_router)
     app.include_router(profile_router)
     app.include_router(system_router)
     return app

--- a/backend/app/routes/__init__.py
+++ b/backend/app/routes/__init__.py
@@ -1,5 +1,6 @@
 from .agents import router as agents_router
 from .ai import router as ai_router
+from .chat_audit import router as chat_audit_router
 from .auth import router as auth_router
 from .cart import router as cart_router
 from .catalog import router as catalog_router
@@ -17,6 +18,7 @@ from .system import router as system_router
 __all__ = [
     "agents_router",
     "ai_router",
+    "chat_audit_router",
     "auth_router",
     "cart_router",
     "catalog_router",

--- a/backend/app/routes/chat_audit.py
+++ b/backend/app/routes/chat_audit.py
@@ -7,7 +7,7 @@ from auth import (
     get_current_staff_required_from_cookie,
     success_response,
 )
-from database import ChatLogDB, UserDB, UserProfileDB, get_db_connection
+from database import AddressDB, ChatLogDB, UserDB, UserProfileDB, get_db_connection
 from ..context import logger
 from ..dependencies import build_staff_scope
 from .ai import _serialize_chat_thread, _serialize_chat_message
@@ -88,10 +88,14 @@ async def list_chat_audit_users(request: Request, q: str = "", offset: int = 0, 
                     u.id AS student_id,
                     COALESCE(NULLIF(TRIM(u.name), ''), NULLIF(TRIM(up.name), ''), u.id) AS display_name,
                     MAX(ct.last_message_at) AS last_chat_at,
-                    COUNT(DISTINCT ct.id) AS thread_count
+                    COUNT(DISTINCT ct.id) AS thread_count,
+                    up.address_id,
+                    a.name AS address_name
                 FROM users u
                 LEFT JOIN user_profiles up
                   ON (up.user_id = u.user_id OR (up.user_id IS NULL AND up.student_id = u.id))
+                LEFT JOIN addresses a
+                  ON a.id = up.address_id
                 INNER JOIN chat_threads ct
                   ON (ct.user_id = u.user_id OR ct.student_id = u.id)
                 WHERE {where_clause}
@@ -110,13 +114,24 @@ async def list_chat_audit_users(request: Request, q: str = "", offset: int = 0, 
                 "display_name": row["display_name"],
                 "last_chat_at": row["last_chat_at"],
                 "thread_count": row["thread_count"],
+                "address_id": row["address_id"],
+                "address_name": row["address_name"],
             })
+
+        # Return staff's own address_ids so frontend can expand them by default
+        staff_address_ids = []
+        if staff.get("type") == "agent":
+            staff_address_ids = scope.get("address_ids") or []
+        else:
+            # Admin: return all address ids (all expanded by default handled on frontend)
+            staff_address_ids = []
 
         return success_response("查询成功", {
             "users": users,
             "total": total,
             "offset": safe_offset,
             "limit": safe_limit,
+            "staff_address_ids": staff_address_ids,
         })
     except Exception as exc:
         logger.error("Failed to list chat audit users: %s", exc)

--- a/backend/app/routes/chat_audit.py
+++ b/backend/app/routes/chat_audit.py
@@ -1,0 +1,198 @@
+from typing import Any, Dict, List, Optional
+
+from fastapi import APIRouter, Request
+
+from auth import (
+    error_response,
+    get_current_staff_required_from_cookie,
+    success_response,
+)
+from database import ChatLogDB, UserDB, UserProfileDB, get_db_connection
+from ..context import logger
+from ..dependencies import build_staff_scope
+from .ai import _serialize_chat_thread, _serialize_chat_message
+
+
+router = APIRouter()
+
+
+def _staff_can_access_user(staff: Dict[str, Any], scope: Dict[str, Any], student_id: str) -> bool:
+    """检查工作人员是否有权查看该用户的聊天记录。"""
+    if staff.get("type") != "agent":
+        return True
+    address_ids = scope.get("address_ids") or []
+    building_ids = scope.get("building_ids") or []
+    if not address_ids and not building_ids:
+        return False
+    profile = UserProfileDB.get_user_profile(student_id)
+    if not profile:
+        return False
+    user_addr = profile.get("address_id")
+    user_bldg = profile.get("building_id")
+    if user_addr and user_addr in address_ids:
+        return True
+    if user_bldg and user_bldg in building_ids:
+        return True
+    return False
+
+
+@router.get("/admin/chat-audit/users")
+async def list_chat_audit_users(request: Request, q: str = "", offset: int = 0, limit: int = 30):
+    """列出有聊天记录的用户，支持搜索和分页。代理仅可见管辖区域用户。"""
+    staff = get_current_staff_required_from_cookie(request)
+    try:
+        scope = build_staff_scope(staff)
+        like = f"%{q.strip()}%" if q.strip() else "%"
+        safe_offset = max(0, offset)
+        safe_limit = max(1, min(limit, 100))
+
+        with get_db_connection() as conn:
+            cur = conn.cursor()
+
+            search_condition = "(u.id LIKE ? OR u.name LIKE ? OR up.name LIKE ?)"
+            params: List[Any] = [like, like, like]
+            filters: List[str] = [search_condition]
+
+            if staff.get("type") == "agent":
+                address_ids = [aid for aid in (scope.get("address_ids") or []) if aid]
+                building_ids = [bid for bid in (scope.get("building_ids") or []) if bid]
+                if not address_ids and not building_ids:
+                    return success_response("查询成功", {"users": [], "total": 0, "offset": safe_offset, "limit": safe_limit})
+                coverage_parts: List[str] = []
+                if address_ids:
+                    placeholders = ",".join("?" * len(address_ids))
+                    coverage_parts.append(f"up.address_id IN ({placeholders})")
+                    params.extend(address_ids)
+                if building_ids:
+                    placeholders = ",".join("?" * len(building_ids))
+                    coverage_parts.append(f"up.building_id IN ({placeholders})")
+                    params.extend(building_ids)
+                filters.append("(" + " OR ".join(coverage_parts) + ")")
+
+            where_clause = " AND ".join(filters)
+
+            count_query = f"""
+                SELECT COUNT(DISTINCT u.id)
+                FROM users u
+                LEFT JOIN user_profiles up
+                  ON (up.user_id = u.user_id OR (up.user_id IS NULL AND up.student_id = u.id))
+                INNER JOIN chat_threads ct
+                  ON (ct.user_id = u.user_id OR ct.student_id = u.id)
+                WHERE {where_clause}
+            """
+            cur.execute(count_query, tuple(params))
+            total = cur.fetchone()[0] or 0
+
+            data_query = f"""
+                SELECT
+                    u.id AS student_id,
+                    COALESCE(NULLIF(TRIM(u.name), ''), NULLIF(TRIM(up.name), ''), u.id) AS display_name,
+                    MAX(ct.last_message_at) AS last_chat_at,
+                    COUNT(DISTINCT ct.id) AS thread_count
+                FROM users u
+                LEFT JOIN user_profiles up
+                  ON (up.user_id = u.user_id OR (up.user_id IS NULL AND up.student_id = u.id))
+                INNER JOIN chat_threads ct
+                  ON (ct.user_id = u.user_id OR ct.student_id = u.id)
+                WHERE {where_clause}
+                GROUP BY u.id
+                ORDER BY last_chat_at DESC
+                LIMIT ? OFFSET ?
+            """
+            data_params = list(params) + [safe_limit, safe_offset]
+            cur.execute(data_query, tuple(data_params))
+            rows = cur.fetchall() or []
+
+        users = []
+        for row in rows:
+            users.append({
+                "student_id": row["student_id"],
+                "display_name": row["display_name"],
+                "last_chat_at": row["last_chat_at"],
+                "thread_count": row["thread_count"],
+            })
+
+        return success_response("查询成功", {
+            "users": users,
+            "total": total,
+            "offset": safe_offset,
+            "limit": safe_limit,
+        })
+    except Exception as exc:
+        logger.error("Failed to list chat audit users: %s", exc)
+        return error_response("查询用户列表失败", 500)
+
+
+@router.get("/admin/chat-audit/users/{student_id}/threads")
+async def list_user_threads(request: Request, student_id: str, limit: int = 50):
+    """获取指定用户的聊天会话列表。"""
+    staff = get_current_staff_required_from_cookie(request)
+    try:
+        scope = build_staff_scope(staff)
+        if not _staff_can_access_user(staff, scope, student_id):
+            return error_response("无权查看该用户的聊天记录", 403)
+
+        user_ref = UserDB.resolve_user_reference(student_id)
+        if not user_ref:
+            return error_response("用户不存在", 404)
+
+        safe_limit = max(1, min(limit, 200))
+
+        with get_db_connection() as conn:
+            cur = conn.cursor()
+            ChatLogDB._ensure_chat_schema(conn)
+            cur.execute('''
+                SELECT *
+                FROM chat_threads
+                WHERE (user_id = ? OR student_id = ?)
+                ORDER BY last_message_at DESC, updated_at DESC
+                LIMIT ?
+            ''', (user_ref['user_id'], user_ref['student_id'], safe_limit))
+            rows = cur.fetchall() or []
+
+        threads = [_serialize_chat_thread(dict(row)) for row in rows]
+        return success_response("查询成功", {"threads": threads})
+    except Exception as exc:
+        logger.error("Failed to list threads for user %s: %s", student_id, exc)
+        return error_response("查询聊天列表失败", 500)
+
+
+@router.get("/admin/chat-audit/threads/{thread_id}/messages")
+async def get_thread_messages(request: Request, thread_id: str, limit: int = 500):
+    """获取指定聊天会话的消息内容。"""
+    staff = get_current_staff_required_from_cookie(request)
+    try:
+        scope = build_staff_scope(staff)
+        safe_limit = max(1, min(limit, 1000))
+
+        with get_db_connection() as conn:
+            cur = conn.cursor()
+            ChatLogDB._ensure_chat_schema(conn)
+
+            cur.execute('SELECT * FROM chat_threads WHERE id = ? LIMIT 1', (thread_id,))
+            thread_row = cur.fetchone()
+            if not thread_row:
+                return error_response("聊天会话不存在", 404)
+            thread = dict(thread_row)
+
+            owner_sid = thread.get("student_id")
+            if owner_sid and not _staff_can_access_user(staff, scope, owner_sid):
+                return error_response("无权查看该聊天记录", 403)
+
+            cur.execute('''
+                SELECT *
+                FROM chat_logs
+                WHERE thread_id = ?
+                ORDER BY timestamp ASC, id ASC
+                LIMIT ?
+            ''', (thread_id, safe_limit))
+            rows = cur.fetchall() or []
+
+        messages = [_serialize_chat_message(dict(row)) for row in rows]
+        return success_response("查询成功", {
+            "thread": _serialize_chat_thread(thread),
+            "messages": messages,
+        })
+    except Exception as exc:
+        logger.error("Failed to get messages for thread %s: %s", thread_id, exc)
+        return error_response("查询聊天内容失败", 500)

--- a/backend/app/routes/chat_audit.py
+++ b/backend/app/routes/chat_audit.py
@@ -7,7 +7,7 @@ from auth import (
     get_current_staff_required_from_cookie,
     success_response,
 )
-from database import AddressDB, ChatLogDB, UserDB, UserProfileDB, get_db_connection
+from database import AddressDB, AgentAssignmentDB, ChatLogDB, UserDB, UserProfileDB, get_db_connection
 from ..context import logger
 from ..dependencies import build_staff_scope
 from .ai import _serialize_chat_thread, _serialize_chat_message
@@ -119,12 +119,16 @@ async def list_chat_audit_users(request: Request, q: str = "", offset: int = 0, 
             })
 
         # Return staff's own address_ids so frontend can expand them by default
-        staff_address_ids = []
         if staff.get("type") == "agent":
             staff_address_ids = scope.get("address_ids") or []
         else:
-            # Admin: return all address ids (all expanded by default handled on frontend)
-            staff_address_ids = []
+            # Admin: look up their own address assignments via agent_id
+            admin_agent_id = staff.get("agent_id")
+            if admin_agent_id:
+                assignments = AgentAssignmentDB.get_buildings_for_agent(admin_agent_id)
+                staff_address_ids = list({a["address_id"] for a in assignments if a.get("address_id")})
+            else:
+                staff_address_ids = []
 
         return success_response("查询成功", {
             "users": users,

--- a/backend/app/routes/settings.py
+++ b/backend/app/routes/settings.py
@@ -44,6 +44,39 @@ async def update_shop_settings(request: Request):
         return error_response("更新商城设置失败", 500)
 
 
+@router.get("/admin/chat-settings")
+async def get_chat_settings(request: Request):
+    """获取聊天保留设置。"""
+    _admin = get_current_admin_required_from_cookie(request)
+    try:
+        days = SettingsDB.get("chat_retention_days", "7")
+        try:
+            days = int(days)
+        except (ValueError, TypeError):
+            days = 7
+        return success_response("获取聊天设置成功", {"chat_retention_days": days})
+    except Exception as exc:
+        logger.error("Failed to fetch chat settings: %s", exc)
+        return error_response("获取聊天设置失败", 500)
+
+
+@router.put("/admin/chat-settings")
+async def update_chat_settings(request: Request):
+    """更新聊天保留设置。0表示永久保留。"""
+    _admin = get_current_admin_required_from_cookie(request)
+    try:
+        body = await request.json()
+        days = body.get("chat_retention_days", 7)
+        days = max(0, int(days))
+        SettingsDB.set("chat_retention_days", str(days))
+        return success_response("聊天设置更新成功", {"chat_retention_days": days})
+    except (ValueError, TypeError):
+        return error_response("保留天数必须为非负整数", 400)
+    except Exception as exc:
+        logger.error("Failed to update chat settings: %s", exc)
+        return error_response("更新聊天设置失败", 500)
+
+
 @router.get("/shop/status")
 async def get_shop_status():
     """获取店铺开关状态。"""

--- a/backend/database/chat.py
+++ b/backend/database/chat.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 from .config import logger
 from .connection import get_db_connection
 from .migrations import ensure_table_columns
+from .settings_db import SettingsDB
 from .users import UserDB
 
 
@@ -310,8 +311,18 @@ class ChatLogDB:
 
 
 def cleanup_old_chat_logs():
-    """清理7天前的聊天记录和关联的会话标题等信息。"""
-    cutoff_date = datetime.now() - timedelta(days=7)
+    """根据管理员设定的保留天数清理聊天记录。设为0则永久保留。"""
+    retention_days_str = SettingsDB.get("chat_retention_days", "7")
+    try:
+        retention_days = int(retention_days_str)
+    except (ValueError, TypeError):
+        retention_days = 7
+
+    if retention_days <= 0:
+        logger.info("Chat retention set to permanent (0), skipping cleanup")
+        return {"deleted_logs": 0, "deleted_threads": 0}
+
+    cutoff_date = datetime.now() - timedelta(days=retention_days)
     cutoff_str = cutoff_date.strftime("%Y-%m-%d %H:%M:%S")
 
     with get_db_connection() as conn:

--- a/components/ChatUI.jsx
+++ b/components/ChatUI.jsx
@@ -7970,3 +7970,5 @@ export default function ChatModern({ user, initialConversationId = null }) {
     </div>
   );
 }
+
+export { Bubble, ThinkingBubble, MarkdownRendererWrapper };

--- a/components/admin/ChatAuditPanel.jsx
+++ b/components/admin/ChatAuditPanel.jsx
@@ -1,0 +1,596 @@
+import React, { useState, useEffect, useRef, useCallback } from 'react';
+import { createPortal } from 'react-dom';
+import { motion, AnimatePresence } from 'framer-motion';
+import {
+  Search, MessageSquare, ChevronLeft, ChevronDown, Settings2, Clock, User,
+  MessageCircle, Loader2, Check, Infinity
+} from 'lucide-react';
+import ChatVendorScripts from '../ChatVendorScripts';
+import { Bubble, ThinkingBubble, MarkdownRendererWrapper } from '../ChatUI';
+
+
+const RETENTION_OPTIONS = [
+  { value: 0, label: '永久保留', icon: <Infinity size={14} /> },
+  { value: 7, label: '7 天' },
+  { value: 14, label: '14 天' },
+  { value: 30, label: '30 天' },
+  { value: 90, label: '90 天' },
+  { value: 365, label: '365 天' },
+];
+
+const PAGE_SIZE = 30;
+
+/**
+ * 将后端返回的 SQLite UTC 时间字符串解析为本地 Date 对象。
+ * SQLite CURRENT_TIMESTAMP 存储的是 UTC，格式 "YYYY-MM-DD HH:MM:SS"。
+ */
+function parseUTCTimestamp(val) {
+  if (!val) return null;
+  if (typeof val === 'number') return new Date(val * 1000);
+  // 将 "YYYY-MM-DD HH:MM:SS" 转为 ISO 8601 UTC 格式以确保按 UTC 解析
+  const iso = String(val).replace(' ', 'T') + 'Z';
+  const d = new Date(iso);
+  return isNaN(d.getTime()) ? null : d;
+}
+
+function formatTime(val) {
+  const d = parseUTCTimestamp(val);
+  if (!d) return '';
+  const pad = (n) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+function relativeTime(val) {
+  const d = parseUTCTimestamp(val);
+  if (!d) return '';
+  const now = Date.now();
+  const diff = now - d.getTime();
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return '刚刚';
+  if (mins < 60) return `${mins}分钟前`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}小时前`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}天前`;
+  const pad = (n) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+}
+
+
+/* ---- Custom Popover Select for retention settings ---- */
+
+const RetentionSelectPopover = ({ value, onChange, disabled }) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [popoverStyle, setPopoverStyle] = useState({});
+  const [animateState, setAnimateState] = useState('closed');
+  const buttonRef = useRef(null);
+  const popoverRef = useRef(null);
+
+  useEffect(() => {
+    const handleClickOutside = (event) => {
+      if (
+        popoverRef.current &&
+        !popoverRef.current.contains(event.target) &&
+        buttonRef.current &&
+        !buttonRef.current.contains(event.target)
+      ) {
+        setIsOpen(false);
+        setAnimateState('closed');
+      }
+    };
+    const handleScroll = () => {
+      if (isOpen) {
+        setIsOpen(false);
+        setAnimateState('closed');
+      }
+    };
+    if (isOpen) {
+      document.addEventListener('mousedown', handleClickOutside);
+      window.addEventListener('scroll', handleScroll, true);
+    }
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      window.removeEventListener('scroll', handleScroll, true);
+    };
+  }, [isOpen]);
+
+  const handleToggle = (e) => {
+    if (disabled) return;
+    e.stopPropagation();
+    if (!isOpen) {
+      const rect = buttonRef.current.getBoundingClientRect();
+      const popoverHeight = 260;
+      const popoverWidth = 180;
+      const spaceBelow = window.innerHeight - rect.bottom;
+      const spaceAbove = rect.top;
+      let finalLeft = rect.left;
+      if (finalLeft + popoverWidth > window.innerWidth) {
+        finalLeft = window.innerWidth - popoverWidth - 10;
+      }
+      if (spaceBelow < popoverHeight && spaceAbove > spaceBelow) {
+        setPopoverStyle({
+          position: 'fixed',
+          bottom: `${window.innerHeight - rect.top + 6}px`,
+          left: `${finalLeft}px`,
+          transformOrigin: 'bottom left',
+        });
+      } else {
+        setPopoverStyle({
+          position: 'fixed',
+          top: `${rect.bottom + 6}px`,
+          left: `${finalLeft}px`,
+          transformOrigin: 'top left',
+        });
+      }
+      setAnimateState('opening');
+      setIsOpen(true);
+      setTimeout(() => setAnimateState('open'), 10);
+    } else {
+      setIsOpen(false);
+      setAnimateState('closed');
+    }
+  };
+
+  const currentLabel = RETENTION_OPTIONS.find((o) => o.value === value)?.label || `${value} 天`;
+
+  return (
+    <>
+      <button
+        ref={buttonRef}
+        onClick={handleToggle}
+        disabled={disabled}
+        className={`inline-flex items-center gap-2 px-3.5 py-1.5 text-sm rounded-xl border transition-all duration-200 ${
+          isOpen
+            ? 'border-blue-300 bg-blue-50 text-blue-700 shadow-sm'
+            : 'border-gray-200 bg-white text-gray-700 hover:border-gray-300 hover:bg-gray-50'
+        } ${disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
+      >
+        <Clock size={14} className="opacity-60" />
+        <span className="font-medium">{currentLabel}</span>
+        <ChevronDown
+          size={14}
+          className={`opacity-50 transition-transform duration-200 ${isOpen ? 'rotate-180' : ''}`}
+        />
+      </button>
+
+      {isOpen && createPortal(
+        <div
+          ref={popoverRef}
+          style={{ ...popoverStyle, zIndex: 9999 }}
+          className={`w-44 bg-white rounded-2xl shadow-xl border border-gray-100 p-1.5 transition-all duration-300 ${
+            animateState === 'open'
+              ? 'opacity-100 scale-100 translate-y-0'
+              : 'opacity-0 scale-90 translate-y-2'
+          }`}
+        >
+          {RETENTION_OPTIONS.map((opt) => {
+            const isSelected = value === opt.value;
+            return (
+              <button
+                key={opt.value}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onChange(opt.value);
+                  setIsOpen(false);
+                  setAnimateState('closed');
+                }}
+                className={`w-full flex items-center gap-2.5 px-3 py-2 rounded-xl text-sm transition-all duration-150 ${
+                  isSelected
+                    ? 'bg-blue-50 text-blue-700 font-medium'
+                    : 'text-gray-600 hover:bg-gray-50'
+                }`}
+              >
+                {opt.icon || <Clock size={14} className="opacity-40" />}
+                <span className="flex-1 text-left">{opt.label}</span>
+                {isSelected && <Check size={14} className="text-blue-500" />}
+              </button>
+            );
+          })}
+        </div>,
+        document.body
+      )}
+    </>
+  );
+};
+
+
+export function ChatAuditPanel({ apiRequest, isAdmin }) {
+  // ---- Retention settings ----
+  const [retentionDays, setRetentionDays] = useState(7);
+  const [retentionLoading, setRetentionLoading] = useState(false);
+  const [showRetention, setShowRetention] = useState(false);
+
+  // ---- User list ----
+  const [users, setUsers] = useState([]);
+  const [usersLoading, setUsersLoading] = useState(false);
+  const [usersTotal, setUsersTotal] = useState(0);
+  const [usersOffset, setUsersOffset] = useState(0);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [debouncedQuery, setDebouncedQuery] = useState('');
+  const userListRef = useRef(null);
+  const loadingMoreRef = useRef(false);
+
+  // ---- Selected user / threads ----
+  const [selectedUser, setSelectedUser] = useState(null);
+  const [threads, setThreads] = useState([]);
+  const [threadsLoading, setThreadsLoading] = useState(false);
+
+  // ---- Selected thread / messages ----
+  const [selectedThread, setSelectedThread] = useState(null);
+  const [selectedThreadInfo, setSelectedThreadInfo] = useState(null);
+  const [messages, setMessages] = useState([]);
+  const [messagesLoading, setMessagesLoading] = useState(false);
+
+  // ---- Debounce search ----
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedQuery(searchQuery), 300);
+    return () => clearTimeout(timer);
+  }, [searchQuery]);
+
+  // ---- Load retention settings ----
+  useEffect(() => {
+    if (!isAdmin) return;
+    (async () => {
+      try {
+        const r = await apiRequest('/admin/chat-settings');
+        if (r?.data?.chat_retention_days !== undefined) {
+          setRetentionDays(r.data.chat_retention_days);
+        }
+      } catch {}
+    })();
+  }, [isAdmin, apiRequest]);
+
+  // ---- Load users ----
+  const loadUsers = useCallback(async (offset = 0, append = false) => {
+    if (!append) setUsersLoading(true);
+    try {
+      const q = encodeURIComponent(debouncedQuery);
+      const r = await apiRequest(`/admin/chat-audit/users?q=${q}&offset=${offset}&limit=${PAGE_SIZE}`);
+      if (r?.data) {
+        const newUsers = r.data.users || [];
+        if (append) {
+          setUsers((prev) => [...prev, ...newUsers]);
+        } else {
+          setUsers(newUsers);
+        }
+        setUsersTotal(r.data.total || 0);
+        setUsersOffset(offset);
+      }
+    } catch (e) {
+      console.error('Failed to load chat audit users:', e);
+    } finally {
+      setUsersLoading(false);
+      loadingMoreRef.current = false;
+    }
+  }, [apiRequest, debouncedQuery]);
+
+  useEffect(() => {
+    setSelectedUser(null);
+    setThreads([]);
+    setSelectedThread(null);
+    setMessages([]);
+    loadUsers(0, false);
+  }, [debouncedQuery, loadUsers]);
+
+  // ---- Infinite scroll for user list ----
+  const handleUserListScroll = useCallback(() => {
+    const el = userListRef.current;
+    if (!el || loadingMoreRef.current) return;
+    const hasMore = users.length < usersTotal;
+    if (!hasMore) return;
+    if (el.scrollTop + el.clientHeight >= el.scrollHeight - 50) {
+      loadingMoreRef.current = true;
+      loadUsers(usersOffset + PAGE_SIZE, true);
+    }
+  }, [users.length, usersTotal, usersOffset, loadUsers]);
+
+  // ---- Load threads for selected user ----
+  useEffect(() => {
+    if (!selectedUser) {
+      setThreads([]);
+      return;
+    }
+    (async () => {
+      setThreadsLoading(true);
+      setSelectedThread(null);
+      setMessages([]);
+      try {
+        const r = await apiRequest(`/admin/chat-audit/users/${encodeURIComponent(selectedUser.student_id)}/threads`);
+        if (r?.data?.threads) {
+          setThreads(r.data.threads);
+        }
+      } catch (e) {
+        console.error('Failed to load threads:', e);
+      } finally {
+        setThreadsLoading(false);
+      }
+    })();
+  }, [selectedUser, apiRequest]);
+
+  // ---- Load messages for selected thread ----
+  useEffect(() => {
+    if (!selectedThread) {
+      setMessages([]);
+      return;
+    }
+    (async () => {
+      setMessagesLoading(true);
+      try {
+        const r = await apiRequest(`/admin/chat-audit/threads/${encodeURIComponent(selectedThread)}/messages`);
+        if (r?.data) {
+          setMessages(r.data.messages || []);
+          setSelectedThreadInfo(r.data.thread || null);
+        }
+      } catch (e) {
+        console.error('Failed to load messages:', e);
+      } finally {
+        setMessagesLoading(false);
+      }
+    })();
+  }, [selectedThread, apiRequest]);
+
+  // ---- Save retention ----
+  const handleRetentionChange = async (val) => {
+    setRetentionLoading(true);
+    try {
+      const r = await apiRequest('/admin/chat-settings', {
+        method: 'PUT',
+        body: JSON.stringify({ chat_retention_days: val }),
+        headers: { 'Content-Type': 'application/json' },
+      });
+      if (r?.data?.chat_retention_days !== undefined) {
+        setRetentionDays(r.data.chat_retention_days);
+      }
+    } catch (e) {
+      console.error('Failed to update retention:', e);
+    } finally {
+      setRetentionLoading(false);
+    }
+  };
+
+  const hasMore = users.length < usersTotal;
+
+  return (
+    <>
+      <ChatVendorScripts />
+      <div className="space-y-4">
+        {/* Header */}
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-gray-800 flex items-center gap-2">
+            <MessageSquare size={20} />
+            聊天审计
+          </h2>
+          {isAdmin && (
+            <button
+              onClick={() => setShowRetention((v) => !v)}
+              className="flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-700 transition-colors px-3 py-1.5 rounded-lg hover:bg-gray-100"
+            >
+              <Settings2 size={16} />
+              保留设置
+            </button>
+          )}
+        </div>
+
+        {/* Retention settings panel */}
+        <AnimatePresence>
+          {isAdmin && showRetention && (
+            <motion.div
+              initial={{ opacity: 0, height: 0 }}
+              animate={{ opacity: 1, height: 'auto' }}
+              exit={{ opacity: 0, height: 0 }}
+              className="overflow-hidden"
+            >
+              <div className="bg-white rounded-xl border border-gray-100 p-4 shadow-sm">
+                <div className="flex items-center gap-4">
+                  <span className="text-sm text-gray-600 whitespace-nowrap">聊天记录保留时间：</span>
+                  <RetentionSelectPopover
+                    value={retentionDays}
+                    onChange={handleRetentionChange}
+                    disabled={retentionLoading}
+                  />
+                  {retentionLoading && <Loader2 size={16} className="animate-spin text-gray-400" />}
+                  <span className="text-xs text-gray-400">
+                    {retentionDays === 0 ? '聊天记录将永久保留' : `超过 ${retentionDays} 天的记录将被自动清理`}
+                  </span>
+                </div>
+              </div>
+            </motion.div>
+          )}
+        </AnimatePresence>
+
+        {/* Main content area */}
+        <div className="flex gap-4 h-[calc(100vh-14rem)]">
+          {/* Left panel - User list */}
+          <div className="w-72 flex-shrink-0 bg-white rounded-xl border border-gray-100 shadow-sm flex flex-col overflow-hidden">
+            {/* Search */}
+            <div className="p-3 border-b border-gray-50">
+              <div className="relative">
+                <Search size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" />
+                <input
+                  type="text"
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                  placeholder="搜索用户..."
+                  className="w-full pl-9 pr-3 py-2 text-sm border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-200 focus:border-blue-400 transition-all"
+                />
+              </div>
+              <div className="text-xs text-gray-400 mt-1.5 px-1">
+                共 {usersTotal} 位用户有聊天记录
+              </div>
+            </div>
+
+            {/* User list with infinite scroll */}
+            <div
+              ref={userListRef}
+              onScroll={handleUserListScroll}
+              className="flex-1 overflow-y-auto custom-scrollbar"
+            >
+              {usersLoading && users.length === 0 ? (
+                <div className="flex items-center justify-center py-12 text-gray-400">
+                  <Loader2 size={20} className="animate-spin" />
+                </div>
+              ) : users.length === 0 ? (
+                <div className="flex flex-col items-center justify-center py-12 text-gray-400 text-sm">
+                  <MessageCircle size={24} className="mb-2 opacity-50" />
+                  暂无聊天记录
+                </div>
+              ) : (
+                <>
+                  {users.map((u) => (
+                    <button
+                      key={u.student_id}
+                      onClick={() => setSelectedUser(u)}
+                      className={`w-full text-left px-4 py-3 border-b border-gray-50 transition-all hover:bg-gray-50 ${
+                        selectedUser?.student_id === u.student_id ? 'bg-blue-50 border-l-2 border-l-blue-400' : ''
+                      }`}
+                    >
+                      <div className="flex items-center justify-between">
+                        <div className="flex items-center gap-2 min-w-0">
+                          <div className="w-7 h-7 rounded-full bg-gray-100 flex items-center justify-center flex-shrink-0">
+                            <User size={14} className="text-gray-500" />
+                          </div>
+                          <div className="min-w-0">
+                            <div className="text-sm font-medium text-gray-800 truncate">{u.display_name}</div>
+                            <div className="text-xs text-gray-400 truncate">{u.student_id}</div>
+                          </div>
+                        </div>
+                        <div className="flex flex-col items-end flex-shrink-0 ml-2">
+                          <span className="text-xs bg-gray-100 text-gray-600 rounded-full px-2 py-0.5">
+                            {u.thread_count}
+                          </span>
+                          <span className="text-[10px] text-gray-400 mt-0.5">{relativeTime(u.last_chat_at)}</span>
+                        </div>
+                      </div>
+                    </button>
+                  ))}
+                  {hasMore && (
+                    <div className="flex items-center justify-center py-3 text-gray-400">
+                      <Loader2 size={16} className="animate-spin" />
+                    </div>
+                  )}
+                </>
+              )}
+            </div>
+          </div>
+
+          {/* Right panel */}
+          <div className="flex-1 bg-white rounded-xl border border-gray-100 shadow-sm flex flex-col overflow-hidden">
+            {!selectedUser ? (
+              /* Empty state */
+              <div className="flex-1 flex flex-col items-center justify-center text-gray-400">
+                <MessageSquare size={40} className="mb-3 opacity-30" />
+                <p className="text-sm">请从左侧选择一个用户查看聊天记录</p>
+              </div>
+            ) : !selectedThread ? (
+              /* Thread list */
+              <div className="flex-1 flex flex-col overflow-hidden">
+                <div className="px-5 py-3.5 border-b border-gray-50 flex items-center gap-2">
+                  <User size={16} className="text-gray-500" />
+                  <span className="text-sm font-medium text-gray-700">{selectedUser.display_name}</span>
+                  <span className="text-xs text-gray-400">({selectedUser.student_id})</span>
+                  <span className="text-xs text-gray-400 ml-auto">{threads.length} 个聊天</span>
+                </div>
+                <div className="flex-1 overflow-y-auto custom-scrollbar">
+                  {threadsLoading ? (
+                    <div className="flex items-center justify-center py-12 text-gray-400">
+                      <Loader2 size={20} className="animate-spin" />
+                    </div>
+                  ) : threads.length === 0 ? (
+                    <div className="flex flex-col items-center justify-center py-12 text-gray-400 text-sm">
+                      暂无聊天记录
+                    </div>
+                  ) : (
+                    threads.map((t) => (
+                      <button
+                        key={t.id}
+                        onClick={() => setSelectedThread(t.id)}
+                        className="w-full text-left px-5 py-3.5 border-b border-gray-50 hover:bg-gray-50 transition-all group"
+                      >
+                        <div className="flex items-center justify-between">
+                          <div className="min-w-0 flex-1">
+                            <div className="text-sm font-medium text-gray-700 truncate group-hover:text-blue-600 transition-colors">
+                              {t.title || t.preview || '未命名聊天'}
+                            </div>
+                          </div>
+                          <div className="flex items-center gap-1.5 text-xs text-gray-400 flex-shrink-0 ml-3">
+                            <Clock size={12} />
+                            {formatTime(t.last_message_at)}
+                          </div>
+                        </div>
+                      </button>
+                    ))
+                  )}
+                </div>
+              </div>
+            ) : (
+              /* Message view */
+              <div className="flex-1 flex flex-col overflow-hidden">
+                {/* Message view header */}
+                <div className="px-5 py-3 border-b border-gray-50 flex items-center gap-3">
+                  <button
+                    onClick={() => {
+                      setSelectedThread(null);
+                      setMessages([]);
+                      setSelectedThreadInfo(null);
+                    }}
+                    className="flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700 transition-colors"
+                  >
+                    <ChevronLeft size={18} />
+                    返回
+                  </button>
+                  <div className="h-4 w-px bg-gray-200" />
+                  <span className="text-sm font-medium text-gray-700 truncate">
+                    {selectedThreadInfo?.title || selectedThreadInfo?.preview || '聊天内容'}
+                  </span>
+                </div>
+
+                {/* Messages */}
+                <div className="flex-1 overflow-y-auto custom-scrollbar px-5 py-4">
+                  {messagesLoading ? (
+                    <div className="flex items-center justify-center py-12 text-gray-400">
+                      <Loader2 size={20} className="animate-spin" />
+                    </div>
+                  ) : messages.length === 0 ? (
+                    <div className="flex flex-col items-center justify-center py-12 text-gray-400 text-sm">
+                      暂无消息
+                    </div>
+                  ) : (
+                    <div className="flex flex-col gap-4 max-w-3xl mx-auto">
+                      {messages.map((m, idx) => {
+                        if (m.role === 'user') {
+                          return (
+                            <div key={m.id || idx}>
+                              <Bubble role="user">{m.content}</Bubble>
+                            </div>
+                          );
+                        }
+                        if (m.role === 'assistant') {
+                          return (
+                            <div key={m.id || idx} className="space-y-2">
+                              {m.thinking_content && (
+                                <ThinkingBubble
+                                  content={m.thinking_content}
+                                  isComplete={true}
+                                  isStopped={!!m.is_thinking_stopped}
+                                  thinkingDuration={m.thinking_duration || null}
+                                />
+                              )}
+                              {m.content && m.content.trim() && (
+                                <MarkdownRendererWrapper content={m.content} isStreaming={false} />
+                              )}
+                            </div>
+                          );
+                        }
+                        return null;
+                      })}
+                    </div>
+                  )}
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/components/admin/ChatAuditPanel.jsx
+++ b/components/admin/ChatAuditPanel.jsx
@@ -444,8 +444,12 @@ export function ChatAuditPanel({ apiRequest, isAdmin }) {
     for (const g of addressGroups) {
       const key = g.address_id || '__unknown__';
       if (isAdmin) {
-        // Admin manages all regions — expand all by default
-        initial[key] = false;
+        // Admin: expand own regions if known, otherwise expand first group only
+        if (staffSet.size > 0) {
+          initial[key] = g.address_id ? !staffSet.has(g.address_id) : true;
+        } else {
+          initial[key] = addressGroups.indexOf(g) !== 0;
+        }
       } else {
         // Agent: expand own regions, collapse rest
         initial[key] = g.address_id ? !staffSet.has(g.address_id) : true;

--- a/components/admin/ChatAuditPanel.jsx
+++ b/components/admin/ChatAuditPanel.jsx
@@ -1,9 +1,9 @@
-import React, { useState, useEffect, useRef, useCallback } from 'react';
+import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { createPortal } from 'react-dom';
 import { motion, AnimatePresence } from 'framer-motion';
 import {
-  Search, MessageSquare, ChevronLeft, ChevronDown, Settings2, Clock, User,
-  MessageCircle, Loader2, Check, Infinity
+  Search, MessageSquare, ChevronLeft, ChevronDown, ChevronRight, Settings2, Clock, User,
+  MessageCircle, Loader2, Check, Infinity, MapPin
 } from 'lucide-react';
 import ChatVendorScripts from '../ChatVendorScripts';
 import { Bubble, ThinkingBubble, MarkdownRendererWrapper } from '../ChatUI';
@@ -54,6 +54,19 @@ function relativeTime(val) {
   if (days < 30) return `${days}天前`;
   const pad = (n) => String(n).padStart(2, '0');
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+}
+
+/** Detect mobile viewport */
+function useIsMobile(breakpoint = 768) {
+  const [isMobile, setIsMobile] = useState(false);
+  useEffect(() => {
+    const mq = window.matchMedia(`(max-width: ${breakpoint - 1}px)`);
+    setIsMobile(mq.matches);
+    const handler = (e) => setIsMobile(e.matches);
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  }, [breakpoint]);
+  return isMobile;
 }
 
 
@@ -194,7 +207,141 @@ const RetentionSelectPopover = ({ value, onChange, disabled }) => {
 };
 
 
+/* ---- User item row ---- */
+const UserRow = ({ user, isSelected, onClick }) => (
+  <button
+    onClick={onClick}
+    className={`w-full text-left px-4 py-3 border-b border-gray-50 transition-all hover:bg-gray-50 ${
+      isSelected ? 'bg-blue-50 border-l-2 border-l-blue-400' : ''
+    }`}
+  >
+    <div className="flex items-center justify-between">
+      <div className="flex items-center gap-2 min-w-0">
+        <div className="w-7 h-7 rounded-full bg-gray-100 flex items-center justify-center flex-shrink-0">
+          <User size={14} className="text-gray-500" />
+        </div>
+        <div className="min-w-0">
+          <div className="text-sm font-medium text-gray-800 truncate">{user.display_name}</div>
+          <div className="text-xs text-gray-400 truncate">{user.student_id}</div>
+        </div>
+      </div>
+      <div className="flex items-center gap-2 flex-shrink-0 ml-2">
+        <div className="flex flex-col items-end">
+          <span className="text-xs bg-gray-100 text-gray-600 rounded-full px-2 py-0.5">
+            {user.thread_count}
+          </span>
+          <span className="text-[10px] text-gray-400 mt-0.5">{relativeTime(user.last_chat_at)}</span>
+        </div>
+        <ChevronRight size={14} className="text-gray-300" />
+      </div>
+    </div>
+  </button>
+);
+
+
+/* ---- Thread item row ---- */
+const ThreadRow = ({ thread, onClick }) => (
+  <button
+    onClick={onClick}
+    className="w-full text-left px-4 py-3.5 border-b border-gray-50 hover:bg-gray-50 transition-all group"
+  >
+    <div className="flex items-center justify-between">
+      <div className="min-w-0 flex-1">
+        <div className="text-sm font-medium text-gray-700 truncate group-hover:text-blue-600 transition-colors">
+          {thread.title || thread.preview || '未命名聊天'}
+        </div>
+      </div>
+      <div className="flex items-center gap-1.5 text-xs text-gray-400 flex-shrink-0 ml-3">
+        <Clock size={12} />
+        {formatTime(thread.last_message_at)}
+      </div>
+    </div>
+  </button>
+);
+
+
+/* ---- Message view ---- */
+const MessageView = ({ messages, messagesLoading }) => (
+  <div className="flex-1 overflow-y-auto custom-scrollbar px-5 py-4">
+    {messagesLoading ? (
+      <div className="flex items-center justify-center py-12 text-gray-400">
+        <Loader2 size={20} className="animate-spin" />
+      </div>
+    ) : messages.length === 0 ? (
+      <div className="flex flex-col items-center justify-center py-12 text-gray-400 text-sm">
+        暂无消息
+      </div>
+    ) : (
+      <div className="flex flex-col gap-4 max-w-3xl mx-auto">
+        {messages.map((m, idx) => {
+          if (m.role === 'user') {
+            return (
+              <div key={m.id || idx}>
+                <Bubble role="user">{m.content}</Bubble>
+              </div>
+            );
+          }
+          if (m.role === 'assistant') {
+            return (
+              <div key={m.id || idx} className="space-y-2">
+                {m.thinking_content && (
+                  <ThinkingBubble
+                    content={m.thinking_content}
+                    isComplete={true}
+                    isStopped={!!m.is_thinking_stopped}
+                    thinkingDuration={m.thinking_duration || null}
+                  />
+                )}
+                {m.content && m.content.trim() && (
+                  <MarkdownRendererWrapper content={m.content} isStreaming={false} />
+                )}
+              </div>
+            );
+          }
+          return null;
+        })}
+      </div>
+    )}
+  </div>
+);
+
+
+/* ---- Group users by address region ---- */
+function groupUsersByAddress(users, staffAddressIds, isAdmin) {
+  const groups = {};
+  const UNKNOWN_KEY = '__unknown__';
+
+  for (const u of users) {
+    const key = u.address_id || UNKNOWN_KEY;
+    if (!groups[key]) {
+      groups[key] = {
+        address_id: u.address_id || null,
+        address_name: u.address_name || '未分配区域',
+        users: [],
+      };
+    }
+    groups[key].users.push(u);
+  }
+
+  // Sort: staff's own addresses first, then others, unknown last
+  const staffSet = new Set(staffAddressIds || []);
+  return Object.values(groups).sort((a, b) => {
+    const aIsStaff = a.address_id && staffSet.has(a.address_id);
+    const bIsStaff = b.address_id && staffSet.has(b.address_id);
+    const aIsUnknown = !a.address_id;
+    const bIsUnknown = !b.address_id;
+    if (aIsStaff && !bIsStaff) return -1;
+    if (!aIsStaff && bIsStaff) return 1;
+    if (aIsUnknown && !bIsUnknown) return 1;
+    if (!aIsUnknown && bIsUnknown) return -1;
+    return 0;
+  });
+}
+
+
 export function ChatAuditPanel({ apiRequest, isAdmin }) {
+  const isMobile = useIsMobile();
+
   // ---- Retention settings ----
   const [retentionDays, setRetentionDays] = useState(7);
   const [retentionLoading, setRetentionLoading] = useState(false);
@@ -207,8 +354,13 @@ export function ChatAuditPanel({ apiRequest, isAdmin }) {
   const [usersOffset, setUsersOffset] = useState(0);
   const [searchQuery, setSearchQuery] = useState('');
   const [debouncedQuery, setDebouncedQuery] = useState('');
+  const [staffAddressIds, setStaffAddressIds] = useState([]);
   const userListRef = useRef(null);
   const loadingMoreRef = useRef(false);
+
+  // ---- Region collapse state ----
+  const [collapsedRegions, setCollapsedRegions] = useState({});
+  const collapsedInitialized = useRef(false);
 
   // ---- Selected user / threads ----
   const [selectedUser, setSelectedUser] = useState(null);
@@ -255,6 +407,9 @@ export function ChatAuditPanel({ apiRequest, isAdmin }) {
         }
         setUsersTotal(r.data.total || 0);
         setUsersOffset(offset);
+        if (r.data.staff_address_ids) {
+          setStaffAddressIds(r.data.staff_address_ids);
+        }
       }
     } catch (e) {
       console.error('Failed to load chat audit users:', e);
@@ -271,6 +426,42 @@ export function ChatAuditPanel({ apiRequest, isAdmin }) {
     setMessages([]);
     loadUsers(0, false);
   }, [debouncedQuery, loadUsers]);
+
+  // ---- Group users by region ----
+  const addressGroups = useMemo(
+    () => groupUsersByAddress(users, staffAddressIds, isAdmin),
+    [users, staffAddressIds, isAdmin]
+  );
+
+  // Initialize collapsed state: expand staff's own regions, collapse others
+  // For admin: expand first region (or all if only a few), collapse rest
+  useEffect(() => {
+    if (collapsedInitialized.current || addressGroups.length === 0) return;
+    collapsedInitialized.current = true;
+
+    const staffSet = new Set(staffAddressIds || []);
+    const initial = {};
+    for (const g of addressGroups) {
+      const key = g.address_id || '__unknown__';
+      if (isAdmin) {
+        // Admin manages all regions — expand all by default
+        initial[key] = false;
+      } else {
+        // Agent: expand own regions, collapse rest
+        initial[key] = g.address_id ? !staffSet.has(g.address_id) : true;
+      }
+    }
+    setCollapsedRegions(initial);
+  }, [addressGroups, staffAddressIds, isAdmin]);
+
+  // Reset collapsed init when search changes
+  useEffect(() => {
+    collapsedInitialized.current = false;
+  }, [debouncedQuery]);
+
+  const toggleRegion = (key) => {
+    setCollapsedRegions((prev) => ({ ...prev, [key]: !prev[key] }));
+  };
 
   // ---- Infinite scroll for user list ----
   const handleUserListScroll = useCallback(() => {
@@ -348,8 +539,245 @@ export function ChatAuditPanel({ apiRequest, isAdmin }) {
     }
   };
 
+  // ---- Navigation handlers ----
+  const handleSelectUser = (u) => {
+    setSelectedUser(u);
+    setSelectedThread(null);
+    setMessages([]);
+    setSelectedThreadInfo(null);
+  };
+
+  const handleBackToUsers = () => {
+    setSelectedUser(null);
+    setThreads([]);
+    setSelectedThread(null);
+    setMessages([]);
+    setSelectedThreadInfo(null);
+  };
+
+  const handleSelectThread = (threadId) => {
+    setSelectedThread(threadId);
+  };
+
+  const handleBackToThreads = () => {
+    setSelectedThread(null);
+    setMessages([]);
+    setSelectedThreadInfo(null);
+  };
+
   const hasMore = users.length < usersTotal;
 
+  // ---- Shared: user list content with region grouping ----
+  const renderUserList = () => {
+    if (usersLoading && users.length === 0) {
+      return (
+        <div className="flex items-center justify-center py-12 text-gray-400">
+          <Loader2 size={20} className="animate-spin" />
+        </div>
+      );
+    }
+    if (users.length === 0) {
+      return (
+        <div className="flex flex-col items-center justify-center py-12 text-gray-400 text-sm">
+          <MessageCircle size={24} className="mb-2 opacity-50" />
+          暂无聊天记录
+        </div>
+      );
+    }
+
+    // If only one group and it's unknown, skip the region header
+    const showGroups = addressGroups.length > 1 || (addressGroups.length === 1 && addressGroups[0].address_id);
+
+    if (!showGroups) {
+      return (
+        <>
+          {users.map((u) => (
+            <UserRow key={u.student_id} user={u} isSelected={selectedUser?.student_id === u.student_id} onClick={() => handleSelectUser(u)} />
+          ))}
+          {hasMore && (
+            <div className="flex items-center justify-center py-3 text-gray-400">
+              <Loader2 size={16} className="animate-spin" />
+            </div>
+          )}
+        </>
+      );
+    }
+
+    return (
+      <>
+        {addressGroups.map((g) => {
+          const key = g.address_id || '__unknown__';
+          const isCollapsed = !!collapsedRegions[key];
+          return (
+            <div key={key}>
+              <button
+                onClick={() => toggleRegion(key)}
+                className="w-full flex items-center gap-2 px-4 py-2 bg-gray-50 hover:bg-gray-100 transition-colors sticky top-0 z-10 border-b border-gray-100"
+              >
+                <ChevronDown
+                  size={14}
+                  className={`text-gray-400 transition-transform duration-200 ${isCollapsed ? '-rotate-90' : ''}`}
+                />
+                <MapPin size={13} className="text-gray-400" />
+                <span className="text-xs font-medium text-gray-600 flex-1 text-left truncate">
+                  {g.address_name}
+                </span>
+                <span className="text-[10px] text-gray-400 bg-white rounded-full px-1.5 py-0.5">
+                  {g.users.length}
+                </span>
+              </button>
+              {!isCollapsed && g.users.map((u) => (
+                <UserRow key={u.student_id} user={u} isSelected={selectedUser?.student_id === u.student_id} onClick={() => handleSelectUser(u)} />
+              ))}
+            </div>
+          );
+        })}
+        {hasMore && (
+          <div className="flex items-center justify-center py-3 text-gray-400">
+            <Loader2 size={16} className="animate-spin" />
+          </div>
+        )}
+      </>
+    );
+  };
+
+  // ---- Shared: thread list content ----
+  const renderThreadList = () => {
+    if (threadsLoading) {
+      return (
+        <div className="flex items-center justify-center py-12 text-gray-400">
+          <Loader2 size={20} className="animate-spin" />
+        </div>
+      );
+    }
+    if (threads.length === 0) {
+      return (
+        <div className="flex flex-col items-center justify-center py-12 text-gray-400 text-sm">
+          暂无聊天记录
+        </div>
+      );
+    }
+    return threads.map((t) => (
+      <ThreadRow key={t.id} thread={t} onClick={() => handleSelectThread(t.id)} />
+    ));
+  };
+
+  /* ============================================================
+   *  MOBILE LAYOUT: full-screen step-by-step navigation
+   * ============================================================ */
+  if (isMobile) {
+    // Step 3: message view
+    if (selectedThread) {
+      return (
+        <>
+          <ChatVendorScripts />
+          <div className="flex flex-col h-[calc(100vh-8rem)] bg-white rounded-xl border border-gray-100 shadow-sm overflow-hidden">
+            {/* Header */}
+            <div className="flex items-center gap-2 px-4 py-3 border-b border-gray-100">
+              <button onClick={handleBackToThreads} className="flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700">
+                <ChevronLeft size={18} />
+                返回
+              </button>
+              <div className="h-4 w-px bg-gray-200" />
+              <span className="text-sm font-medium text-gray-700 truncate flex-1">
+                {selectedThreadInfo?.title || selectedThreadInfo?.preview || '聊天内容'}
+              </span>
+            </div>
+            <MessageView messages={messages} messagesLoading={messagesLoading} />
+          </div>
+        </>
+      );
+    }
+
+    // Step 2: thread list for selected user
+    if (selectedUser) {
+      return (
+        <>
+          <ChatVendorScripts />
+          <div className="flex flex-col h-[calc(100vh-8rem)] bg-white rounded-xl border border-gray-100 shadow-sm overflow-hidden">
+            <div className="flex items-center gap-2 px-4 py-3 border-b border-gray-100">
+              <button onClick={handleBackToUsers} className="flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700">
+                <ChevronLeft size={18} />
+                返回
+              </button>
+              <div className="h-4 w-px bg-gray-200" />
+              <User size={14} className="text-gray-500" />
+              <span className="text-sm font-medium text-gray-700 truncate">{selectedUser.display_name}</span>
+              <span className="text-xs text-gray-400 ml-auto">{threads.length} 个聊天</span>
+            </div>
+            <div className="flex-1 overflow-y-auto custom-scrollbar">
+              {renderThreadList()}
+            </div>
+          </div>
+        </>
+      );
+    }
+
+    // Step 1: user list
+    return (
+      <>
+        <ChatVendorScripts />
+        <div className="flex flex-col h-[calc(100vh-8rem)] bg-white rounded-xl border border-gray-100 shadow-sm overflow-hidden">
+          {/* Header */}
+          <div className="flex items-center justify-between px-4 py-3 border-b border-gray-100">
+            <h2 className="text-lg font-semibold text-gray-800 flex items-center gap-2">
+              <MessageSquare size={20} />
+              聊天审计
+            </h2>
+            {isAdmin && (
+              <button
+                onClick={() => setShowRetention((v) => !v)}
+                className="flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-700 px-2 py-1 rounded-lg hover:bg-gray-100"
+              >
+                <Settings2 size={16} />
+              </button>
+            )}
+          </div>
+
+          {/* Retention (mobile) */}
+          <AnimatePresence>
+            {isAdmin && showRetention && (
+              <motion.div initial={{ opacity: 0, height: 0 }} animate={{ opacity: 1, height: 'auto' }} exit={{ opacity: 0, height: 0 }} className="overflow-hidden">
+                <div className="border-b border-gray-100 px-4 py-3">
+                  <div className="flex items-center gap-3 flex-wrap">
+                    <span className="text-sm text-gray-600">保留时间：</span>
+                    <RetentionSelectPopover value={retentionDays} onChange={handleRetentionChange} disabled={retentionLoading} />
+                    {retentionLoading && <Loader2 size={16} className="animate-spin text-gray-400" />}
+                  </div>
+                </div>
+              </motion.div>
+            )}
+          </AnimatePresence>
+
+          {/* Search */}
+          <div className="px-4 py-3 border-b border-gray-50">
+            <div className="relative">
+              <Search size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" />
+              <input
+                type="text"
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                placeholder="搜索用户..."
+                className="w-full pl-9 pr-3 py-2 text-sm border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-200 focus:border-blue-400 transition-all"
+              />
+            </div>
+            <div className="text-xs text-gray-400 mt-1.5 px-1">
+              共 {usersTotal} 位用户有聊天记录
+            </div>
+          </div>
+
+          {/* User list */}
+          <div ref={userListRef} onScroll={handleUserListScroll} className="flex-1 overflow-y-auto custom-scrollbar">
+            {renderUserList()}
+          </div>
+        </div>
+      </>
+    );
+  }
+
+  /* ============================================================
+   *  DESKTOP LAYOUT: left panel (users or threads) + right panel (messages)
+   * ============================================================ */
   return (
     <>
       <ChatVendorScripts />
@@ -400,192 +828,88 @@ export function ChatAuditPanel({ apiRequest, isAdmin }) {
 
         {/* Main content area */}
         <div className="flex gap-4 h-[calc(100vh-14rem)]">
-          {/* Left panel - User list */}
+          {/* Left panel: User list OR Thread list */}
           <div className="w-72 flex-shrink-0 bg-white rounded-xl border border-gray-100 shadow-sm flex flex-col overflow-hidden">
-            {/* Search */}
-            <div className="p-3 border-b border-gray-50">
-              <div className="relative">
-                <Search size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" />
-                <input
-                  type="text"
-                  value={searchQuery}
-                  onChange={(e) => setSearchQuery(e.target.value)}
-                  placeholder="搜索用户..."
-                  className="w-full pl-9 pr-3 py-2 text-sm border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-200 focus:border-blue-400 transition-all"
-                />
-              </div>
-              <div className="text-xs text-gray-400 mt-1.5 px-1">
-                共 {usersTotal} 位用户有聊天记录
-              </div>
-            </div>
+            {!selectedUser ? (
+              /* ---- User list view ---- */
+              <>
+                {/* Search */}
+                <div className="p-3 border-b border-gray-50">
+                  <div className="relative">
+                    <Search size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" />
+                    <input
+                      type="text"
+                      value={searchQuery}
+                      onChange={(e) => setSearchQuery(e.target.value)}
+                      placeholder="搜索用户..."
+                      className="w-full pl-9 pr-3 py-2 text-sm border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-200 focus:border-blue-400 transition-all"
+                    />
+                  </div>
+                  <div className="text-xs text-gray-400 mt-1.5 px-1">
+                    共 {usersTotal} 位用户有聊天记录
+                  </div>
+                </div>
 
-            {/* User list with infinite scroll */}
-            <div
-              ref={userListRef}
-              onScroll={handleUserListScroll}
-              className="flex-1 overflow-y-auto custom-scrollbar"
-            >
-              {usersLoading && users.length === 0 ? (
-                <div className="flex items-center justify-center py-12 text-gray-400">
-                  <Loader2 size={20} className="animate-spin" />
+                {/* User list */}
+                <div ref={userListRef} onScroll={handleUserListScroll} className="flex-1 overflow-y-auto custom-scrollbar">
+                  {renderUserList()}
                 </div>
-              ) : users.length === 0 ? (
-                <div className="flex flex-col items-center justify-center py-12 text-gray-400 text-sm">
-                  <MessageCircle size={24} className="mb-2 opacity-50" />
-                  暂无聊天记录
-                </div>
-              ) : (
-                <>
-                  {users.map((u) => (
-                    <button
-                      key={u.student_id}
-                      onClick={() => setSelectedUser(u)}
-                      className={`w-full text-left px-4 py-3 border-b border-gray-50 transition-all hover:bg-gray-50 ${
-                        selectedUser?.student_id === u.student_id ? 'bg-blue-50 border-l-2 border-l-blue-400' : ''
-                      }`}
-                    >
-                      <div className="flex items-center justify-between">
-                        <div className="flex items-center gap-2 min-w-0">
-                          <div className="w-7 h-7 rounded-full bg-gray-100 flex items-center justify-center flex-shrink-0">
-                            <User size={14} className="text-gray-500" />
-                          </div>
-                          <div className="min-w-0">
-                            <div className="text-sm font-medium text-gray-800 truncate">{u.display_name}</div>
-                            <div className="text-xs text-gray-400 truncate">{u.student_id}</div>
-                          </div>
-                        </div>
-                        <div className="flex flex-col items-end flex-shrink-0 ml-2">
-                          <span className="text-xs bg-gray-100 text-gray-600 rounded-full px-2 py-0.5">
-                            {u.thread_count}
-                          </span>
-                          <span className="text-[10px] text-gray-400 mt-0.5">{relativeTime(u.last_chat_at)}</span>
-                        </div>
-                      </div>
-                    </button>
-                  ))}
-                  {hasMore && (
-                    <div className="flex items-center justify-center py-3 text-gray-400">
-                      <Loader2 size={16} className="animate-spin" />
+              </>
+            ) : (
+              /* ---- Thread list view (after selecting user) ---- */
+              <>
+                {/* Back + user info header */}
+                <div className="px-3 py-3 border-b border-gray-50">
+                  <button
+                    onClick={handleBackToUsers}
+                    className="flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700 transition-colors mb-2"
+                  >
+                    <ChevronLeft size={16} />
+                    <span>返回用户列表</span>
+                  </button>
+                  <div className="flex items-center gap-2">
+                    <div className="w-7 h-7 rounded-full bg-blue-50 flex items-center justify-center flex-shrink-0">
+                      <User size={14} className="text-blue-500" />
                     </div>
-                  )}
-                </>
-              )}
-            </div>
+                    <div className="min-w-0">
+                      <div className="text-sm font-medium text-gray-800 truncate">{selectedUser.display_name}</div>
+                      <div className="text-xs text-gray-400 truncate">{selectedUser.student_id}</div>
+                    </div>
+                    <span className="text-xs text-gray-400 ml-auto">{threads.length} 个聊天</span>
+                  </div>
+                </div>
+
+                {/* Thread list */}
+                <div className="flex-1 overflow-y-auto custom-scrollbar">
+                  {renderThreadList()}
+                </div>
+              </>
+            )}
           </div>
 
-          {/* Right panel */}
+          {/* Right panel: Message view */}
           <div className="flex-1 bg-white rounded-xl border border-gray-100 shadow-sm flex flex-col overflow-hidden">
-            {!selectedUser ? (
+            {!selectedThread ? (
               /* Empty state */
               <div className="flex-1 flex flex-col items-center justify-center text-gray-400">
                 <MessageSquare size={40} className="mb-3 opacity-30" />
-                <p className="text-sm">请从左侧选择一个用户查看聊天记录</p>
-              </div>
-            ) : !selectedThread ? (
-              /* Thread list */
-              <div className="flex-1 flex flex-col overflow-hidden">
-                <div className="px-5 py-3.5 border-b border-gray-50 flex items-center gap-2">
-                  <User size={16} className="text-gray-500" />
-                  <span className="text-sm font-medium text-gray-700">{selectedUser.display_name}</span>
-                  <span className="text-xs text-gray-400">({selectedUser.student_id})</span>
-                  <span className="text-xs text-gray-400 ml-auto">{threads.length} 个聊天</span>
-                </div>
-                <div className="flex-1 overflow-y-auto custom-scrollbar">
-                  {threadsLoading ? (
-                    <div className="flex items-center justify-center py-12 text-gray-400">
-                      <Loader2 size={20} className="animate-spin" />
-                    </div>
-                  ) : threads.length === 0 ? (
-                    <div className="flex flex-col items-center justify-center py-12 text-gray-400 text-sm">
-                      暂无聊天记录
-                    </div>
-                  ) : (
-                    threads.map((t) => (
-                      <button
-                        key={t.id}
-                        onClick={() => setSelectedThread(t.id)}
-                        className="w-full text-left px-5 py-3.5 border-b border-gray-50 hover:bg-gray-50 transition-all group"
-                      >
-                        <div className="flex items-center justify-between">
-                          <div className="min-w-0 flex-1">
-                            <div className="text-sm font-medium text-gray-700 truncate group-hover:text-blue-600 transition-colors">
-                              {t.title || t.preview || '未命名聊天'}
-                            </div>
-                          </div>
-                          <div className="flex items-center gap-1.5 text-xs text-gray-400 flex-shrink-0 ml-3">
-                            <Clock size={12} />
-                            {formatTime(t.last_message_at)}
-                          </div>
-                        </div>
-                      </button>
-                    ))
-                  )}
-                </div>
+                <p className="text-sm">
+                  {!selectedUser ? '请从左侧选择一个用户查看聊天记录' : '请从左侧选择一个聊天查看内容'}
+                </p>
               </div>
             ) : (
               /* Message view */
               <div className="flex-1 flex flex-col overflow-hidden">
                 {/* Message view header */}
                 <div className="px-5 py-3 border-b border-gray-50 flex items-center gap-3">
-                  <button
-                    onClick={() => {
-                      setSelectedThread(null);
-                      setMessages([]);
-                      setSelectedThreadInfo(null);
-                    }}
-                    className="flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700 transition-colors"
-                  >
-                    <ChevronLeft size={18} />
-                    返回
-                  </button>
-                  <div className="h-4 w-px bg-gray-200" />
+                  <MessageSquare size={16} className="text-gray-400" />
                   <span className="text-sm font-medium text-gray-700 truncate">
                     {selectedThreadInfo?.title || selectedThreadInfo?.preview || '聊天内容'}
                   </span>
                 </div>
 
                 {/* Messages */}
-                <div className="flex-1 overflow-y-auto custom-scrollbar px-5 py-4">
-                  {messagesLoading ? (
-                    <div className="flex items-center justify-center py-12 text-gray-400">
-                      <Loader2 size={20} className="animate-spin" />
-                    </div>
-                  ) : messages.length === 0 ? (
-                    <div className="flex flex-col items-center justify-center py-12 text-gray-400 text-sm">
-                      暂无消息
-                    </div>
-                  ) : (
-                    <div className="flex flex-col gap-4 max-w-3xl mx-auto">
-                      {messages.map((m, idx) => {
-                        if (m.role === 'user') {
-                          return (
-                            <div key={m.id || idx}>
-                              <Bubble role="user">{m.content}</Bubble>
-                            </div>
-                          );
-                        }
-                        if (m.role === 'assistant') {
-                          return (
-                            <div key={m.id || idx} className="space-y-2">
-                              {m.thinking_content && (
-                                <ThinkingBubble
-                                  content={m.thinking_content}
-                                  isComplete={true}
-                                  isStopped={!!m.is_thinking_stopped}
-                                  thinkingDuration={m.thinking_duration || null}
-                                />
-                              )}
-                              {m.content && m.content.trim() && (
-                                <MarkdownRendererWrapper content={m.content} isStreaming={false} />
-                              )}
-                            </div>
-                          );
-                        }
-                        return null;
-                      })}
-                    </div>
-                  )}
-                </div>
+                <MessageView messages={messages} messagesLoading={messagesLoading} />
               </div>
             )}
           </div>

--- a/pages/admin.js
+++ b/pages/admin.js
@@ -16,20 +16,21 @@ import { GiftThresholdPanel } from '../components/admin/GiftThresholdPanel';
 import { CouponsPanel } from '../components/admin/CouponsPanel';
 import { PaymentQrPanel } from '../components/admin/PaymentQrPanel';
 import { DeliverySettingsPanel } from '../components/admin/DeliverySettingsPanel';
+import { ChatAuditPanel } from '../components/admin/ChatAuditPanel';
 import { useAdminWarnings } from '../components/admin/hooks/useAdminWarnings';
 import { useOrderManagement } from '../components/admin/hooks/useOrderManagement';
 import { useAddressManagement } from '../components/admin/hooks/useAddressManagement';
 import { useAgentManagement } from '../components/admin/hooks/useAgentManagement';
 import { useProductManagement } from '../components/admin/hooks/useProductManagement';
 import { motion, AnimatePresence } from 'framer-motion';
-import { 
-  Package, ClipboardList, Gift, Ticket, QrCode, MapPin, UserCog, Settings, LayoutDashboard
+import {
+  Package, ClipboardList, Gift, Ticket, QrCode, MapPin, UserCog, Settings, LayoutDashboard, MessageSquareText
 } from 'lucide-react';
 import { AdminSidebar } from '../components/admin/AdminSidebar';
 import { OverviewPanel } from '../components/admin/OverviewPanel';
 
-const ADMIN_TABS = ['overview', 'products', 'orders', 'addresses', 'agents', 'lottery', 'autoGifts', 'coupons', 'paymentQrs'];
-const AGENT_TABS = ['overview', 'products', 'orders', 'lottery', 'autoGifts', 'coupons', 'paymentQrs'];
+const ADMIN_TABS = ['overview', 'products', 'orders', 'addresses', 'agents', 'chatAudit', 'lottery', 'autoGifts', 'coupons', 'paymentQrs'];
+const AGENT_TABS = ['overview', 'products', 'orders', 'chatAudit', 'lottery', 'autoGifts', 'coupons', 'paymentQrs'];
 
 function StaffPortalPage({ role = 'admin', navActive = 'staff-backend', initialTab = 'overview' }) {
   const router = useRouter();
@@ -358,6 +359,7 @@ function StaffPortalPage({ role = 'admin', navActive = 'staff-backend', initialT
       { id: 'addresses', label: '地址管理', icon: <MapPin size={18} /> },
       { id: 'agents', label: '代理管理', icon: <UserCog size={18} /> }
     ] : []),
+    ...(allowedTabs.includes('chatAudit') ? [{ id: 'chatAudit', label: '聊天审计', icon: <MessageSquareText size={18} /> }] : []),
     ...(allowedTabs.includes('lottery') ? [{ 
       id: 'lottery', 
       label: '抽奖配置', 
@@ -536,6 +538,10 @@ function StaffPortalPage({ role = 'admin', navActive = 'staff-backend', initialT
                     handleAgentDelete={handleAgentDelete}
                     setShowDeletedAgentsModal={setShowDeletedAgentsModal}
                   />
+                )}
+
+                {activeTab === 'chatAudit' && (
+                  <ChatAuditPanel apiRequest={apiRequest} isAdmin={isAdminView} />
                 )}
 
                 {activeTab === 'coupons' && <CouponsPanel apiPrefix={staffPrefix} apiRequest={apiRequest} />}


### PR DESCRIPTION
## Summary
- Add a **聊天审计** (Chat Audit) tab to the admin/agent panel for viewing users' AI chat history
- Admins can see all users; agents are scoped to users within their assigned buildings/addresses
- Left panel: searchable user list with infinite scroll; right panel: thread browser → full message view
- Chat messages reuse existing `Bubble` and `MarkdownRendererWrapper` components from ChatUI
- Admins can configure chat retention period (7/14/30/90/365 days or permanent); the cleanup job now reads this setting instead of a hardcoded 7 days
- All timestamps are properly converted from UTC to the device's local timezone
- Retention dropdown uses a custom portal-based popover matching the project's existing UI patterns

## Changed files
| File | Change |
|------|--------|
| `backend/app/routes/chat_audit.py` | **New** — 3 audit API endpoints (users, threads, messages) with agent-scoped access control |
| `components/admin/ChatAuditPanel.jsx` | **New** — Audit panel UI with user list, thread list, message viewer, retention settings |
| `backend/app/routes/settings.py` | Add `GET/PUT /admin/chat-settings` for retention config |
| `backend/database/chat.py` | `cleanup_old_chat_logs()` reads configurable retention; 0 = permanent |
| `components/ChatUI.jsx` | Export `Bubble`, `ThinkingBubble`, `MarkdownRendererWrapper` |
| `pages/admin.js` | Register `chatAudit` tab for both admin and agent roles |
| `backend/app/routes/__init__.py`, `backend/app/__init__.py` | Wire up `chat_audit_router` |

## Test plan
- [ ] Admin login → verify "聊天审计" tab appears in sidebar
- [ ] Agent login → verify tab appears but only shows users in assigned region
- [ ] Search users, scroll to load more (infinite scroll)
- [ ] Click user → see thread list; click thread → see full messages
- [ ] User messages render in right-side bubbles; AI responses render as Markdown
- [ ] Admin: change retention setting → verify it persists on reload
- [ ] Set retention to "永久保留" (0) → verify chat cleanup skips deletion
- [ ] Verify all displayed timestamps match the device's local timezone

🤖 Generated with [Claude Code](https://claude.com/claude-code)